### PR TITLE
setting .gitignore as a proper filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Thumbs.db
 .idea/
 venv/
 __pycache__/
+Lib/
+Scripts/
+etc/
+pyvenv.cfg
+share/
+.ipynb_checkpoints/


### PR DESCRIPTION
@Cal16king @andrewjack7887 I'm just sending you a repaired .gitignore . You had a gitignore.txt file that wasn't going to work for filtering out virtual environment file. This one should work for you so you can actively set this repo as a Python workspace.